### PR TITLE
Replace the default rpc node for WalletConnect

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -31,7 +31,7 @@ export const injected = new InjectedConnector({
 })
 
 export const walletconnect = new WalletConnectConnector({
-  rpc: { 100: 'https://xdai.1hive.org' },
+  rpc: { 100: 'https://rpc.xdaichain.com/' },
   bridge: 'https://bridge.walletconnect.org',
   qrcode: true,
   pollingInterval: 15000


### PR DESCRIPTION
Our node lacks configuration, so we should be using xDai's node until we improve our node.