### PR TITLE
Update default-token-list package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.0.0",
     "ethers": "^5.0.7",
-    "honeyswap-default-token-list": "^2.10.0",
+    "@1hive/default-token-list": "^3.2.1",
     "i18next": "^15.0.9",
     "i18next-browser-languagedetector": "^3.0.1",
     "i18next-xhr-backend": "^2.0.1",

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -42,7 +42,7 @@ import { computeTradePriceBreakdown, warningSeverity } from '../../utils/prices'
 import AppBody from '../AppBody'
 import { ClickableText } from '../Pool/styleds'
 import { addTokenToMetamask } from '../../utils/addTokenToMetamask'
-import tokenList from 'honeyswap-default-token-list'
+import tokenList from '@1hive/default-token-list'
 
 export default function Swap() {
   const loadedUrlParams = useDefaultsFromURLSearch()

--- a/src/state/lists/reducer.test.ts
+++ b/src/state/lists/reducer.test.ts
@@ -3,7 +3,7 @@ import { DEFAULT_LIST_OF_LISTS, DEFAULT_TOKEN_LIST_URL } from '../../constants/l
 import { updateVersion } from '../global/actions'
 import { fetchTokenList, acceptListUpdate, addList, removeList, selectList } from './actions'
 import reducer, { ListsState } from './reducer'
-import UNISWAP_DEFAULT_TOKEN_LIST from 'honeyswap-default-token-list'
+import UNISWAP_DEFAULT_TOKEN_LIST from '@1hive/default-token-list'
 
 const STUB_TOKEN_LIST = {
   name: '',

--- a/src/state/lists/reducer.ts
+++ b/src/state/lists/reducer.ts
@@ -4,7 +4,7 @@ import { TokenList } from '@uniswap/token-lists/dist/types'
 import { DEFAULT_LIST_OF_LISTS, DEFAULT_TOKEN_LIST_URL } from '../../constants/lists'
 import { updateVersion } from '../global/actions'
 import { acceptListUpdate, addList, fetchTokenList, removeList, selectList } from './actions'
-import UNISWAP_DEFAULT_LIST from 'honeyswap-default-token-list'
+import UNISWAP_DEFAULT_LIST from '@1hive/default-token-list'
 
 export interface ListsState {
   readonly byUrl: {

--- a/src/utils/addTokenToMetamask.ts
+++ b/src/utils/addTokenToMetamask.ts
@@ -1,5 +1,5 @@
 import { Token } from 'uniswap-xdai-sdk'
-import tokenList from 'honeyswap-default-token-list'
+import tokenList from '@1hive/default-token-list'
 
 export async function addTokenToMetamask(ethereum: any, token: Token) {
   const selectedToken = tokenList.tokens.find(t => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@1hive/default-token-list@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@1hive/default-token-list/-/default-token-list-3.2.1.tgz#cd3466c08dafa7ed971cc861e35f47b42f4bad56"
+  integrity sha512-3Gb5rZFl4vZiheSPEZODGssxk7noFg7yqvKPMolersFPJTOB/t38XiKba9Dq5n7+ZW1tpRdWfR+ExIpkqSAVig==
+
 "@babel/code-frame@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -7928,11 +7933,6 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
-
-honeyswap-default-token-list@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/honeyswap-default-token-list/-/honeyswap-default-token-list-2.10.0.tgz#8f67c0e6e5a00eca55676dad4e95114da491c215"
-  integrity sha512-W5TYeotKPxT45KFYFWXLqIcE4DxRu3o5xGA9kSzSPjs3mFmeZktdItOQs+Sd4nLc3heWXo3PcE1aGSg3KClt6w==
 
 hosted-git-info@^2.1.4:
   version "2.8.8"


### PR DESCRIPTION
We are deprecating package `honeyswap-default-token-list` in favor of `@1hive/default-token-list`.