### PR TITLE
Change default gas limit to 1M when adding liquidity so tx does not fail

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -173,7 +173,7 @@ export default function AddLiquidity({
 
     method(...args, {
       ...(value ? { value } : {}),
-      gasLimit: 10000000
+      gasLimit: 1000000
     })
       .then(response => {
         setAttemptingTxn(false)


### PR DESCRIPTION
Lowered the gas limit calculation when adding liquidity from 10M to 1M so the transaction doesn't fail by default