### PR TITLE
fix gas limit issue on xDAi (hardcoded)

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -172,8 +172,7 @@ export default function AddLiquidity({
     setAttemptingTxn(true)
 
     method(...args, {
-      ...(value ? { value } : {}),
-      gasLimit: 1000000
+      ...(value ? { value } : {})
     })
       .then(response => {
         setAttemptingTxn(false)


### PR DESCRIPTION
The gas limit was being hardcoded when providing Liquidity, skipping the node calculation for the transaction.
I removed that hardcoded variable
